### PR TITLE
Add backend auth/db packages

### DIFF
--- a/livestreampro/backend/go.mod
+++ b/livestreampro/backend/go.mod
@@ -2,3 +2,5 @@
 module livestreampro
 
 go 1.22
+
+require github.com/lib/pq v1.10.9

--- a/livestreampro/backend/go.sum
+++ b/livestreampro/backend/go.sum
@@ -1,0 +1,2 @@
+github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=

--- a/livestreampro/backend/internal/auth/README.md
+++ b/livestreampro/backend/internal/auth/README.md
@@ -1,0 +1,3 @@
+Package auth defines authentication-related interfaces and basic stubs used by
+other backend services. These stubs allow the API gateway and other components
+to compile before a real implementation is added.

--- a/livestreampro/backend/internal/auth/service.go
+++ b/livestreampro/backend/internal/auth/service.go
@@ -1,0 +1,23 @@
+// /home/${USER}/livestreampro/backend/internal/auth/service.go
+package auth
+
+import "context"
+
+// Service defines authentication operations used across the backend.
+type Service interface {
+	// Login authenticates a user and returns a JWT token on success.
+	Login(ctx context.Context, username, password string) (string, error)
+	// Logout invalidates the provided token.
+	Logout(ctx context.Context, token string) error
+}
+
+// StubService is a placeholder implementation that allows other packages to compile.
+type StubService struct{}
+
+func (s *StubService) Login(ctx context.Context, username, password string) (string, error) {
+	return "stub-token", nil
+}
+
+func (s *StubService) Logout(ctx context.Context, token string) error {
+	return nil
+}

--- a/livestreampro/backend/internal/auth/service_test.go
+++ b/livestreampro/backend/internal/auth/service_test.go
@@ -1,0 +1,23 @@
+// /home/${USER}/livestreampro/backend/internal/auth/service_test.go
+package auth
+
+import (
+	"context"
+	"testing"
+)
+
+func TestStubService(t *testing.T) {
+	var _ Service = (*StubService)(nil)
+
+	s := &StubService{}
+	token, err := s.Login(context.Background(), "user", "pass")
+	if err != nil {
+		t.Fatalf("login error: %v", err)
+	}
+	if token == "" {
+		t.Fatalf("expected token")
+	}
+	if err := s.Logout(context.Background(), token); err != nil {
+		t.Fatalf("logout error: %v", err)
+	}
+}

--- a/livestreampro/backend/internal/db/README.md
+++ b/livestreampro/backend/internal/db/README.md
@@ -1,0 +1,3 @@
+Package db contains a minimal PostgreSQL client using database/sql.
+It centralizes connection logic so other packages can obtain *sql.DB
+instances without managing driver specifics.

--- a/livestreampro/backend/internal/db/db.go
+++ b/livestreampro/backend/internal/db/db.go
@@ -1,0 +1,14 @@
+// /home/${USER}/livestreampro/backend/internal/db/db.go
+package db
+
+import (
+	"database/sql"
+
+	_ "github.com/lib/pq"
+)
+
+// Connect opens a PostgreSQL database using the provided connection string.
+// The caller is responsible for closing the returned *sql.DB.
+func Connect(connStr string) (*sql.DB, error) {
+	return sql.Open("postgres", connStr)
+}

--- a/livestreampro/backend/internal/db/db_test.go
+++ b/livestreampro/backend/internal/db/db_test.go
@@ -1,0 +1,16 @@
+// /home/${USER}/livestreampro/backend/internal/db/db_test.go
+package db
+
+import "testing"
+
+func TestConnectInvalid(t *testing.T) {
+	d, err := Connect("postgres://invalid")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer d.Close()
+
+	if err := d.Ping(); err == nil {
+		t.Fatalf("expected ping error for invalid connection")
+	}
+}


### PR DESCRIPTION
## Summary
- add starter `auth` and `db` packages under `backend/internal`
- wire up minimal postgres client using lib/pq
- provide stub auth service and accompanying tests
- vendor lib/pq in go module

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6868058b6f64832793fb30844e1c0adc