### PR TITLE
Organize SRE runbooks

### DIFF
--- a/livestreampro/README.md
+++ b/livestreampro/README.md
@@ -55,6 +55,8 @@
 │   ├── moderation-policy.md
 │   ├── dmca-policy.md
 │   └── sre/runbooks/
+│       ├── general.md
+│       └── stream-outage.md
 └── .github/workflows/     # CI/CD pipelines
 ```
 

--- a/livestreampro/docs/sre/runbook.md
+++ b/livestreampro/docs/sre/runbook.md
@@ -1,4 +1,0 @@
-<!-- /home/${USER}/livestreampro/docs/sre/runbook.md -->
-# SRE Runbook
-
-TBD

--- a/livestreampro/docs/sre/runbooks/general.md
+++ b/livestreampro/docs/sre/runbooks/general.md
@@ -1,0 +1,4 @@
+<!-- /home/${USER}/livestreampro/docs/sre/runbooks/general.md -->
+# SRE Runbook
+
+TBD

--- a/livestreampro/docs/sre/runbooks/stream-outage.md
+++ b/livestreampro/docs/sre/runbooks/stream-outage.md
@@ -1,0 +1,21 @@
+<!-- /home/${USER}/livestreampro/docs/sre/runbooks/stream-outage.md -->
+# Stream Outage
+
+Use this runbook when live streams are unavailable or failing to load for viewers.
+
+## Detection
+- Monitor alerts from the streaming pipeline (e.g., CDN 5xx errors).
+- Reports from on-call engineers or support.
+
+## Immediate Actions
+1. Confirm the scope of outage and affected regions.
+2. Restart impacted streaming services or pods if necessary.
+3. Notify stakeholders in the incident channel.
+
+## Resolution
+- Investigate root cause (e.g., transcoder failure, network issues).
+- Apply fixes or rollbacks as required.
+
+## Postmortem
+- Document timeline, impact, and resolution steps.
+- Identify follow-up actions to prevent recurrence.


### PR DESCRIPTION
## Summary
- organize SRE docs under `docs/sre/runbooks/`
- add new `stream-outage.md` incident runbook
- list runbook files in README

## Testing
- `make lint` *(fails: missing separator)*

------
https://chatgpt.com/codex/tasks/task_e_686806e284188327be18d44057c0a617