### PR TITLE
Add contributing guide and update README

### DIFF
--- a/livestreampro/README.md
+++ b/livestreampro/README.md
@@ -190,7 +190,7 @@ Autoscaling is handled by **KEDA** (CPU, GPU, NATS lag, WebRTC sessions).
 3. Run `make pre-commit` before pushing.
 4. Open PR → CI must pass, at least one maintainer review.
 
-Full guidelines in `docs/contributing.md`.
+Full guidelines in [docs/contributing.md](docs/contributing.md).
 
 ---
 

--- a/livestreampro/docs/contributing.md
+++ b/livestreampro/docs/contributing.md
@@ -1,0 +1,16 @@
+<!-- /home/${USER}/livestreampro/docs/contributing.md -->
+# Contributing Guide
+
+## Branching & Conventional Commits
+- Branch from `main` using descriptive names such as `feat/stream-chat` or `fix/login-bug`.
+- Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: add chat widget`).
+- Squash merge requests to keep history linear.
+
+## Formatting & Linting
+- Run `make lint` to execute `golangci-lint` for Go and `npm run lint` for the frontend.
+- Code must be formatted with `gofmt` and Prettier; CI will fail otherwise.
+
+## Pull Requests & CI
+- Push your branch and open a PR against `main`.
+- At least one maintainer review is required before merge.
+- GitHub Actions run `make lint`, `make test-backend`, and `make test-frontend` for every PR. All checks must pass.


### PR DESCRIPTION
## Summary
- document branching, commit, and PR workflow in `docs/contributing.md`
- link to the guide from the README

## Testing
- `go test ./...` *(in backend)*
- `npm test` *(fails: Invalid package.json)*
- `make lint` *(fails: Makefile missing separator)*

------
https://chatgpt.com/codex/tasks/task_e_686806e4b1808327b6026631645541f0