### PR TITLE
Add DMCA and moderation policies

### DIFF
--- a/livestreampro/docs/dmca-policy.md
+++ b/livestreampro/docs/dmca-policy.md
@@ -1,4 +1,33 @@
 <!-- /home/${USER}/livestreampro/docs/dmca-policy.md -->
 # DMCA Policy
 
-TBD
+LivestreamPro is an open source project released under the [Apache License 2.0](../LICENSE). We respect the rights of copyright holders and comply with the Digital Millennium Copyright Act (DMCA).
+
+## Submitting a Takedown Notice
+
+If you believe material distributed through this project infringes your copyright, please send a written notice containing the following information:
+
+1. Identification of the copyrighted work claimed to have been infringed.
+2. Identification of the material that is claimed to be infringing and information reasonably sufficient to permit us to locate the material (repository name, file path, and commit reference, if available).
+3. Your contact information including name, address, telephone number, and email address.
+4. A statement that you have a good-faith belief that the disputed use is not authorized by the copyright owner, its agent, or the law.
+5. A statement, made under penalty of perjury, that the information in the notification is accurate and that you are the copyright owner or are authorized to act on the owner's behalf.
+6. Your physical or electronic signature.
+
+Please direct DMCA notices to:
+
+```
+Attn: DMCA Agent
+Email: dmca@example.com
+Address: 123 Open Source Drive, Sample City, Country
+```
+
+Upon receipt of a valid notice, we may remove or disable access to the referenced material. When appropriate, we will retain a historical copy to satisfy attribution requirements under the Apache 2.0 license.
+
+## Counter Notification
+
+If you believe your content was removed in error, you may submit a counter notice with information sufficient for us to evaluate your claim. The process mirrors the requirements above. We will forward valid counter notices to the original complainant and may restore the material unless they seek a court order within the timeframe permitted by law.
+
+## Updates
+
+This policy may be updated from time to time. It does not constitute legal advice.

--- a/livestreampro/docs/moderation-policy.md
+++ b/livestreampro/docs/moderation-policy.md
@@ -1,4 +1,22 @@
 <!-- /home/${USER}/livestreampro/docs/moderation-policy.md -->
 # Moderation Policy
 
-TBD
+LivestreamPro welcomes contributions from the community. All code and content in this repository is distributed under the [Apache License 2.0](../LICENSE). In order to keep the project healthy and in compliance with the license and applicable law, we may moderate contributions and user-generated content.
+
+## Reporting Issues
+
+If you encounter content that is unlawful, abusive, or otherwise violates this policy or the Apache 2.0 license, please report it to the maintainers. Include a link to the relevant repository path or commit and a brief description of the problem.
+
+```
+Email: report@example.com
+```
+
+We review reports as quickly as possible. Depending on the nature of the violation, we may remove the offending material, block further submissions, or take other appropriate action.
+
+## Enforcement
+
+Project maintainers have discretion to edit, remove, or reject contributions that do not align with this policy or that could put the project in legal jeopardy. Repeated or egregious violations may result in bans from participation in project forums and repositories.
+
+## Updates
+
+This policy may change as the project evolves. It is provided for information only and does not constitute legal advice.


### PR DESCRIPTION
## Summary
- add a simple DMCA policy with a takedown procedure
- outline moderation guidelines for community submissions

## Testing
- `make lint` *(fails: missing separator in Makefile)*
- `make test-backend` *(fails: missing separator in Makefile)*

------
https://chatgpt.com/codex/tasks/task_e_686806e9708c83278236b8c8201566ee