### PR TITLE
Add lint and proto generation configs

### DIFF
--- a/livestreampro/.golangci.yml
+++ b/livestreampro/.golangci.yml
@@ -1,0 +1,4 @@
+linters:
+  enable:
+    - govet
+    - golint

--- a/livestreampro/README.md
+++ b/livestreampro/README.md
@@ -73,6 +73,13 @@
 | Go             | 1.22    |
 | Make           | 4.4     |
 
+### Install Required Tooling
+
+```bash
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+go install github.com/bufbuild/buf/cmd/buf@latest
+```
+
 ### One-Command Bootstrap
 
 ```bash

--- a/livestreampro/buf.gen.yaml
+++ b/livestreampro/buf.gen.yaml
@@ -1,0 +1,12 @@
+version: v1
+plugins:
+  - remote: buf.build/protocolbuffers/go
+    out: backend/gen/go
+    opt: paths=source_relative
+  - remote: buf.build/protocolbuffers/go-grpc
+    out: backend/gen/go
+    opt: paths=source_relative
+  - remote: buf.build/bufbuild/es
+    out: frontend/src/proto
+    opt:
+      - target=ts


### PR DESCRIPTION
## Summary
- configure golangci-lint with govet and golint
- add buf.gen.yaml for Go and TypeScript stub generation
- document installing golangci-lint and buf

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68683eca90248327b293aecf2955e52b