### PR TITLE
Add Trivy scanning in CI

### DIFF
--- a/livestreampro/.github/workflows/ci.yml
+++ b/livestreampro/.github/workflows/ci.yml
@@ -19,3 +19,13 @@ jobs:
       - run: make lint
       - run: make test-backend
       - run: make test-frontend
+      - name: Build API gateway image
+        run: docker build -t api-gateway:${{ github.sha }} ./backend/cmd/api-gateway
+      - name: Scan image with Trivy
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: api-gateway:${{ github.sha }}
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'HIGH,CRITICAL'

--- a/livestreampro/README.md
+++ b/livestreampro/README.md
@@ -116,9 +116,11 @@ NEXT_PUBLIC_HLS_URL=http://localhost:8080/hls
 | ------------- | -------------------------- | ----------------- |
 | Unit          | `go test`, Jest            | push / PR         |
 | Integration   | Testcontainers, Playwright | PR matrix         |
-| Security      | Trivy, Snyk                | PR blocker        |
+| Security      | Trivy (fail on HIGH+), Snyk | PR blocker        |
 | Accessibility | Lighthouse CI              | FE PRs            |
 | Chaos         | LitmusChaos                | nightly (staging) |
+
+Trivy scans all built Docker images and the job fails if any vulnerabilities with severity **HIGH** or greater are detected.
 
 Run locally:
 

--- a/livestreampro/backend/cmd/api-gateway/Dockerfile
+++ b/livestreampro/backend/cmd/api-gateway/Dockerfile
@@ -1,0 +1,10 @@
+# Build stage
+FROM golang:1.22 as builder
+WORKDIR /src
+COPY ../../../.. .
+RUN CGO_ENABLED=0 go build -o /app/api-gateway ./livestreampro/backend/cmd/api-gateway
+
+# Final stage
+FROM alpine:3.18
+COPY --from=builder /app/api-gateway /api-gateway
+ENTRYPOINT ["/api-gateway"]


### PR DESCRIPTION
## Summary
- scan the API gateway Docker image with Trivy in CI
- add a Dockerfile for the API gateway to build the image
- mention Trivy HIGH+ requirement in README

## Testing
- `make pre-commit` *(fails: missing separator in Makefile)*

------
https://chatgpt.com/codex/tasks/task_e_68683ecc32788327b1173e21e1c1071b