### PR TITLE
Add env templates

### DIFF
--- a/livestreampro/.gitignore
+++ b/livestreampro/.gitignore
@@ -1,6 +1,10 @@
 # General
 node_modules/
 *.log
+backend/.env
+frontend/.env.local
+!backend/.env.example
+!frontend/.env.local.example
 .env
 .env.local
 *.swp

--- a/livestreampro/README.md
+++ b/livestreampro/README.md
@@ -100,6 +100,10 @@ npm run android   # or: npm run ios
 
 ## 5  Configuration
 
+Template environment files are provided in `backend/.env.example` and
+`frontend/.env.local.example`. Copy them to `.env` and `.env.local`
+respectively before starting the application.
+
 Create the following files (never commit secrets):
 
 ```ini

--- a/livestreampro/backend/.env.example
+++ b/livestreampro/backend/.env.example
@@ -1,0 +1,5 @@
+POSTGRES_URL=postgres://stream:stream@db:5432/streams?sslmode=disable
+REDIS_URL=redis://redis:6379/0
+NATS_URL=nats://nats:4222
+JWT_SECRET=change-me
+VAULT_ADDR=http://vault:8200

--- a/livestreampro/frontend/.env.local.example
+++ b/livestreampro/frontend/.env.local.example
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_API_BASE=http://localhost:8080
+NEXT_PUBLIC_HLS_URL=http://localhost:8080/hls


### PR DESCRIPTION
## Summary
- add backend/.env.example and frontend/.env.local.example
- ignore real env files but keep templates
- document using the example env files

## Testing
- `go test ./...`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6868410ed5f48327825127419491ad09